### PR TITLE
onblur in IE doesn't have relatedTarget

### DIFF
--- a/src/Select/Events.elm
+++ b/src/Select/Events.elm
@@ -64,4 +64,4 @@ onBlurAttribute config state =
                 |> Decode.map (Maybe.map attrToMsg)
                 |> Decode.map (Maybe.withDefault OnBlur)
     in
-        on "blur" blur
+        on "focusout" blur


### PR DESCRIPTION
 (FF neither I believe) focusout does

tested in: 
- Chrome 56
- FF 52 (below FF 52 it doesn't work)
- IE 11