### PR TITLE
add withNotFoundHidden option

### DIFF
--- a/example/src/Example2.elm
+++ b/example/src/Example2.elm
@@ -48,6 +48,7 @@ selectConfig =
         |> Select.withInputClass "col-12"
         |> Select.withMenuClass "border border-gray bg-white"
         |> Select.withItemClass "border-bottom border-silver p1"
+        |> Select.withNotFoundHidden
         |> Select.withCutoff 12
         |> Select.withOnQuery OnQuery
 

--- a/example/src/Example2.elm
+++ b/example/src/Example2.elm
@@ -48,7 +48,7 @@ selectConfig =
         |> Select.withInputClass "col-12"
         |> Select.withMenuClass "border border-gray bg-white"
         |> Select.withItemClass "border-bottom border-silver p1"
-        |> Select.withNotFoundHidden
+        |> Select.withNotFoundShown False
         |> Select.withCutoff 12
         |> Select.withOnQuery OnQuery
 

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -27,7 +27,7 @@ module Select
         , withMenuStyles
         , withNotFound
         , withNotFoundClass
-        , withNotFoundHidden
+        , withNotFoundShown
         , withNotFoundStyles
         , withOnQuery
         , withPrompt
@@ -66,7 +66,7 @@ module Select
 
 # Configure the not found message
 
-@docs withNotFound, withNotFoundClass, withNotFoundHidden, withNotFoundStyles
+@docs withNotFound, withNotFoundClass, withNotFoundShown, withNotFoundStyles
 
 # Configure the prompt
 
@@ -353,15 +353,15 @@ withNotFoundClass class config =
 
 
 {-|
-Hide menu when no matches found unless withNotFoundClass or withNotFoundStyles is used
+Hide menu when no matches found
 
-    Select.withNotFoundHidden config
+    Select.withNotFoundShown False config
 -}
-withNotFoundHidden : Config msg item -> Config msg item
-withNotFoundHidden config =
+withNotFoundShown : Bool -> Config msg item -> Config msg item
+withNotFoundShown shown config =
     let
         fn c =
-            { c | notFoundHidden = [ ( "display", "none" ) ] }
+            { c | notFoundShown = shown }
     in
         fmapConfig fn config
 

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -27,6 +27,7 @@ module Select
         , withMenuStyles
         , withNotFound
         , withNotFoundClass
+        , withNotFoundHidden
         , withNotFoundStyles
         , withOnQuery
         , withPrompt
@@ -65,7 +66,7 @@ module Select
 
 # Configure the not found message
 
-@docs withNotFound, withNotFoundClass, withNotFoundStyles
+@docs withNotFound, withNotFoundClass, withNotFoundHidden, withNotFoundStyles
 
 # Configure the prompt
 
@@ -347,6 +348,20 @@ withNotFoundClass class config =
     let
         fn c =
             { c | notFoundClass = class }
+    in
+        fmapConfig fn config
+
+
+{-|
+Hide menu when no matches found unless withNotFoundClass or withNotFoundStyles is used
+
+    Select.withNotFoundHidden config
+-}
+withNotFoundHidden : Config msg item -> Config msg item
+withNotFoundHidden config =
+    let
+        fn c =
+            { c | notFoundHidden = [ ( "display", "none" ) ] }
     in
         fmapConfig fn config
 

--- a/src/Select/Models.elm
+++ b/src/Select/Models.elm
@@ -26,7 +26,7 @@ type alias Config msg item =
     , menuStyles : List Style
     , notFound : String
     , notFoundClass : String
-    , notFoundHidden : List Style
+    , notFoundShown : Bool
     , notFoundStyles : List Style
     , onQueryChange : Maybe (String -> msg)
     , onSelect : Maybe item -> msg
@@ -60,7 +60,7 @@ newConfig onSelect toLabel =
     , menuStyles = []
     , notFound = "No results found"
     , notFoundClass = ""
-    , notFoundHidden = []
+    , notFoundShown = True
     , notFoundStyles = []
     , onQueryChange = Nothing
     , onSelect = onSelect

--- a/src/Select/Models.elm
+++ b/src/Select/Models.elm
@@ -26,6 +26,7 @@ type alias Config msg item =
     , menuStyles : List Style
     , notFound : String
     , notFoundClass : String
+    , notFoundHidden : List Style
     , notFoundStyles : List Style
     , onQueryChange : Maybe (String -> msg)
     , onSelect : Maybe item -> msg
@@ -59,6 +60,7 @@ newConfig onSelect toLabel =
     , menuStyles = []
     , notFound = "No results found"
     , notFoundClass = ""
+    , notFoundHidden = []
     , notFoundStyles = []
     , onQueryChange = Nothing
     , onSelect = onSelect

--- a/src/Select/Select/Menu.elm
+++ b/src/Select/Select/Menu.elm
@@ -33,13 +33,8 @@ view config model items selected =
                 text ""
 
         menuStyle =
-            if
-                (relevantItems == [])
-                    && (config.notFoundStyles == [])
-                    && (config.notFoundClass == "")
-                    && (config.notFoundHidden /= [])
-            then
-                style config.notFoundHidden
+            if relevantItems == [] && config.notFoundShown == False then
+                style [ ( "display", "none" ) ]
             else
                 style (viewStyles config)
 

--- a/src/Select/Select/Menu.elm
+++ b/src/Select/Select/Menu.elm
@@ -32,6 +32,17 @@ view config model items selected =
             else
                 text ""
 
+        menuStyle =
+            if
+                (relevantItems == [])
+                    && (config.notFoundStyles == [])
+                    && (config.notFoundClass == "")
+                    && (config.notFoundHidden /= [])
+            then
+                style config.notFoundHidden
+            else
+                style (viewStyles config)
+
         -- Treat Nothing and "" as empty query
         query =
             model.query
@@ -40,7 +51,7 @@ view config model items selected =
         menu =
             div
                 [ viewClassAttr config
-                , style (viewStyles config)
+                , menuStyle
                 ]
                 (noResultElement :: elements)
     in


### PR DESCRIPTION
Added `withNotFoundHidden` which hides the menu unless the user uses `withNotFoundClass` or `withNotFoundStyles`. Added this to Example2.elm, but maybe you would prefer it somewhere else?