### PR TITLE
Navigation with arrow keys

### DIFF
--- a/example/src/Example1.elm
+++ b/example/src/Example1.elm
@@ -89,6 +89,8 @@ selectConfig =
         |> Select.withNotFound "No matches"
         |> Select.withNotFoundClass "red"
         |> Select.withNotFoundStyles [ ( "padding", "0 2rem" ) ]
+        |> Select.withHighlightedItemClass "bg-silver"
+        |> Select.withHighlightedItemStyles [ ( "color", "black" ) ]
         |> Select.withPrompt "Select a movie"
         |> Select.withPromptClass "grey"
         |> Select.withUnderlineClass "underline"

--- a/example/src/Example2.elm
+++ b/example/src/Example2.elm
@@ -49,6 +49,8 @@ selectConfig =
         |> Select.withMenuClass "border border-gray bg-white"
         |> Select.withItemClass "border-bottom border-silver p1"
         |> Select.withNotFoundShown False
+        |> Select.withHighlightedItemClass "bg-silver"
+        |> Select.withHighlightedItemStyles [ ( "color", "black" ) ]
         |> Select.withCutoff 12
         |> Select.withOnQuery OnQuery
 

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -30,6 +30,8 @@ module Select
         , withNotFoundClass
         , withNotFoundShown
         , withNotFoundStyles
+        , withHighlightedItemClass
+        , withHighlightedItemStyles
         , withOnQuery
         , withPrompt
         , withPromptClass
@@ -397,6 +399,32 @@ withNotFoundStyles styles config =
     in
         fmapConfig fn config
 
+
+{-| Class for the hightlighted tem
+
+    Select.withHighlightedItemClass "red" config
+
+-}
+withHighlightedItemClass : String -> Config msg item -> Config msg item
+withHighlightedItemClass class config =
+    let
+        fn c =
+            { c | highlightedItemClass = class }
+    in
+        fmapConfig fn config
+
+{-| Styles for the highlighted item
+
+    Select.withHighlightedItemStyles [("padding", "1rem")] config
+
+-}
+withHighlightedItemStyles : List ( String, String ) -> Config msg item -> Config msg item
+withHighlightedItemStyles styles config =
+    let
+        fn c =
+            { c | highlightedItemStyles = styles }
+    in
+        fmapConfig fn config
 
 {-| Add a callback for when the query changes
 

--- a/src/Select/Events.elm
+++ b/src/Select/Events.elm
@@ -23,30 +23,6 @@ traceDecoder message decoder =
             |> Decode.andThen log
 
 
-onEnterOrSpace : msg -> Attribute msg
-onEnterOrSpace msg =
-    let
-        isEnterOrSpace code =
-            if code == 13 || code == 32 then
-                Decode.succeed msg
-            else
-                Decode.fail "not ENTER"
-    in
-        on "keyup" (Decode.andThen isEnterOrSpace keyCode)
-
-
-onEsc : msg -> Attribute msg
-onEsc msg =
-    let
-        isEsc code =
-            if code == 27 then
-                Decode.succeed msg
-            else
-                Decode.fail "not ENTER"
-    in
-        on "keyup" (Decode.andThen isEsc keyCode)
-
-
 onBlurAttribute : Config msg item -> State -> Attribute (Msg item)
 onBlurAttribute config state =
     let

--- a/src/Select/Messages.elm
+++ b/src/Select/Messages.elm
@@ -6,5 +6,7 @@ type Msg item
     | OnBlur
     | OnClear
     | OnEsc
+    | OnDownArrow
+    | OnUpArrow
     | OnQueryChange String
     | OnSelect item

--- a/src/Select/Models.elm
+++ b/src/Select/Models.elm
@@ -29,6 +29,8 @@ type alias Config msg item =
     , notFoundClass : String
     , notFoundShown : Bool
     , notFoundStyles : List Style
+    , highlightedItemClass : String
+    , highlightedItemStyles : List Style
     , onQueryChange : Maybe (String -> msg)
     , onSelect : Maybe item -> msg
     , prompt : String
@@ -65,6 +67,8 @@ newConfig onSelect toLabel =
     , notFoundClass = ""
     , notFoundShown = True
     , notFoundStyles = []
+    , highlightedItemClass = ""
+    , highlightedItemStyles = []
     , onQueryChange = Nothing
     , onSelect = onSelect
     , prompt = ""
@@ -84,6 +88,7 @@ transformQuery query =
 type alias State =
     { id : String
     , query : Maybe String
+    , highlightedItem : Maybe Int
     }
 
 
@@ -91,4 +96,5 @@ newState : String -> State
 newState id =
     { id = id
     , query = Nothing
+    , highlightedItem = Nothing
     }

--- a/src/Select/Select.elm
+++ b/src/Select/Select.elm
@@ -18,6 +18,6 @@ view config model items selected =
             [ ( "position", "relative" ) ]
     in
         div [ id model.id, class classes, style styles ]
-            [ Select.Select.Input.view config model selected
+            [ Select.Select.Input.view config model items selected
             , Select.Select.Menu.view config model items
             ]

--- a/src/Select/Select/Input.elm
+++ b/src/Select/Select/Input.elm
@@ -21,7 +21,7 @@ onKeyUpAttribute maybeItem =
             Just item -> Decode.succeed (OnSelect item)
 
         fn code =
-            case Debug.log "input keycode" code of
+            case code of
                 13 ->
                     selectItem
 

--- a/src/Select/Select/Item.elm
+++ b/src/Select/Select/Item.elm
@@ -1,52 +1,44 @@
 module Select.Select.Item exposing (..)
 
 import Html exposing (..)
-import Html.Attributes exposing (attribute, class, style, tabindex)
-import Html.Events exposing (onClick, on, keyCode)
-import Json.Decode as Decode
-import Select.Events exposing (onBlurAttribute)
+import Html.Attributes exposing (attribute, class, style)
+import Html.Events exposing (onMouseDown)
 import Select.Messages exposing (..)
 import Select.Models exposing (..)
 import Select.Utils exposing (referenceAttr)
 
-
-onKeyUpAttribute : item -> Attribute (Msg item)
-onKeyUpAttribute item =
+view : Config msg item -> State -> Int -> Int -> item -> Html (Msg item)
+view config state itemCount index item =
     let
-        fn code =
-            case code of
-                13 ->
-                    Decode.succeed (OnSelect item)
 
-                32 ->
-                    Decode.succeed (OnSelect item)
+        ( highlightedItemClass, highlightedItemStyles ) =
+          case state.highlightedItem of
+            Nothing -> ( "", [] )
+            Just highlighted ->
+              -- take remainder as item numbers wrap around
+              if (rem highlighted itemCount) == index
+                then ( config.highlightedItemClass, config.highlightedItemStyles )
+                else ( "", [] )
 
-                27 ->
-                    Decode.succeed OnEsc
-
-                _ ->
-                    Decode.fail "not ENTER"
-    in
-        on "keyup" (Decode.andThen fn keyCode)
-
-
-view : Config msg item -> State -> item -> Html (Msg item)
-view config state item =
-    let
         classes =
-            baseItemClasses config
+            String.join " "
+                [ baseItemClasses config
+                , highlightedItemClass
+                ]
 
         styles =
-            ( "cursor", "pointer" ) :: (baseItemStyles config)
+            List.concat
+                [ [ ( "cursor", "pointer" ) ]
+                , baseItemStyles config
+                , highlightedItemStyles
+                ]
+
     in
         div
             [ class classes
-            , onBlurAttribute config state
-            , onClick (OnSelect item)
-            , onKeyUpAttribute item
+            , onMouseDown (OnSelect item)
             , referenceAttr config state
             , style styles
-            , tabindex 0
             ]
             [ text (config.toLabel item)
             ]

--- a/src/Select/Select/Item.elm
+++ b/src/Select/Select/Item.elm
@@ -7,18 +7,21 @@ import Select.Messages exposing (..)
 import Select.Models exposing (..)
 import Select.Utils exposing (referenceAttr)
 
+
 view : Config msg item -> State -> Int -> Int -> item -> Html (Msg item)
 view config state itemCount index item =
     let
-
         ( highlightedItemClass, highlightedItemStyles ) =
-          case state.highlightedItem of
-            Nothing -> ( "", [] )
-            Just highlighted ->
-              -- take remainder as item numbers wrap around
-              if (rem highlighted itemCount) == index
-                then ( config.highlightedItemClass, config.highlightedItemStyles )
-                else ( "", [] )
+            case state.highlightedItem of
+                Nothing ->
+                    ( "", [] )
+
+                Just highlighted ->
+                    -- take remainder as item numbers wrap around
+                    if rem highlighted itemCount == index then
+                        ( config.highlightedItemClass, config.highlightedItemStyles )
+                    else
+                        ( "", [] )
 
         classes =
             String.join " "
@@ -32,7 +35,6 @@ view config state itemCount index item =
                 , baseItemStyles config
                 , highlightedItemStyles
                 ]
-
     in
         div
             [ class classes

--- a/src/Select/Select/Menu.elm
+++ b/src/Select/Select/Menu.elm
@@ -17,7 +17,7 @@ view config model items =
                 |> Maybe.withDefault ""
 
         searchResult =
-            Utils.matchedItems config model items
+            Utils.matchedItemsWithCutoff config model items
     in
         if query == "" then
             text ""
@@ -47,17 +47,12 @@ menu config model matchedItems =
             else
                 text ""
 
-        withCutoff =
-            case config.cutoff of
-                Just n ->
-                    List.take n matchedItems
-
-                Nothing ->
-                    matchedItems
+        itemCount =
+          List.length matchedItems
 
         elements =
-            withCutoff
-                |> List.map (Item.view config model)
+            matchedItems
+                |> List.indexedMap (Item.view config model itemCount)
     in
         div
             [ viewClassAttr config

--- a/src/Select/Update.elm
+++ b/src/Select/Update.elm
@@ -14,6 +14,25 @@ update config msg model =
         OnEsc ->
             ( { model | query = Nothing }, Cmd.none )
 
+        OnDownArrow ->
+            let
+                newHightlightedItem =
+                  case model.highlightedItem of
+                    Nothing -> Just 0
+                    Just n -> Just (n + 1)
+            in
+              ( { model | highlightedItem =  newHightlightedItem }, Cmd.none )
+
+        OnUpArrow ->
+            let
+                newHightlightedItem =
+                  case model.highlightedItem of
+                    Nothing -> Nothing
+                    Just 0 -> Nothing
+                    Just n -> Just (n - 1)
+            in
+              ( { model | highlightedItem =  newHightlightedItem }, Cmd.none)
+
         OnBlur ->
             ( { model | query = Nothing }, Cmd.none )
 
@@ -36,7 +55,7 @@ update config msg model =
                             Task.succeed value
                                 |> Task.perform constructor
             in
-                ( { model | query = Just value }, cmd )
+                ( { model | highlightedItem = Nothing, query = Just value }, cmd )
 
         OnSelect item ->
             let

--- a/src/Select/Utils.elm
+++ b/src/Select/Utils.elm
@@ -67,6 +67,22 @@ fuzzyInsertPenalty config options =
             options
 
 
+matchedItemsWithCutoff : Config msg item -> State -> List item -> SearchResult item
+matchedItemsWithCutoff config model items =
+  case matchedItems config model items of
+
+    NotSearched ->
+      NotSearched
+
+    ItemsFound matching ->
+      case config.cutoff of
+
+        Just n ->
+          ItemsFound (List.take n matching)
+
+        Nothing ->
+          ItemsFound matching
+
 matchedItems : Config msg item -> State -> List item -> SearchResult item
 matchedItems config model items =
     let


### PR DESCRIPTION
This resolves #10 

As discussed in #10  it works by storing an index of the item highlighted by the arrow keys in the state and dispenses with using focus to select an item.

All keyboard input is now handled in `Select.Input` and no longer in `Select.Item`

To avoid the `Update` needing knowledge of the how many items are in the menu, the down key just keeps incrementing the index indefinitely (beyond the end of the list) and then a modulus of the index is used in the view to highlight and select the correct item.

The class and styles of the highlighted item can be set with `withHighlightedItemClass` and `withHighlightedItemStyles` respectively.

One minor issue is that the up arrow causes the cursor to also move to start of the input field.  I think this is difficult to fix as it would involve using `preventDefault` only for the up arrow, but not for the tab key, which is not easily supported in Elm 0.18.  According to https://github.com/elm-lang/virtual-dom/issues/18 Elm 0.19 will allow this to be fixed.