### PR TITLE
Allow configuration of input ID

### DIFF
--- a/demo/src/Example1.elm
+++ b/demo/src/Example1.elm
@@ -84,6 +84,7 @@ selectConfig : Select.Config Msg Movie
 selectConfig =
     Select.newConfig OnSelect .label
         |> Select.withCutoff 12
+        |> Select.withInputId "input-id"
         |> Select.withInputClass "col-12"
         |> Select.withInputStyles [ ( "padding", "0.5rem" ), ( "outline", "none" ) ]
         |> Select.withItemClass "border-bottom border-silver p1 gray"

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -18,6 +18,7 @@ module Select
         , withFuzzySearchRemovePenalty
         , withFuzzySearchInsertPenalty
         , withFuzzySearchSeparators
+        , withInputId
         , withInputClass
         , withInputStyles
         , withInputWrapperClass
@@ -60,7 +61,7 @@ module Select
 
 # Configure the input
 
-@docs withInputClass, withInputStyles, withInputWrapperClass, withInputWrapperStyles
+@docs withInputId, withInputClass, withInputStyles, withInputWrapperClass, withInputWrapperStyles
 
 
 # Configure an underline element under the input
@@ -231,6 +232,19 @@ withCutoff n config =
     in
         fmapConfig fn config
 
+
+{-| Set the ID of the input
+
+    Select.withInputId "input-id" config
+
+-}
+withInputId : String -> Config msg item -> Config msg item
+withInputId id config =
+    let
+        fn c =
+            { c | inputId = Just id }
+    in
+        fmapConfig fn config
 
 {-| Add classes to the input
 

--- a/src/Select/Models.elm
+++ b/src/Select/Models.elm
@@ -17,6 +17,7 @@ type alias Config msg item =
     , fuzzySearchRemovePenalty : Maybe Int
     , fuzzySearchInsertPenalty : Maybe Int
     , fuzzySearchSeparators : List String
+    , inputId : Maybe String
     , inputClass : String
     , inputStyles : List Style
     , inputWrapperClass : String
@@ -55,6 +56,7 @@ newConfig onSelect toLabel =
     , fuzzySearchRemovePenalty = Nothing
     , fuzzySearchInsertPenalty = Nothing
     , fuzzySearchSeparators = []
+    , inputId = Nothing
     , inputClass = ""
     , inputStyles = []
     , inputWrapperClass = ""

--- a/src/Select/Select/Input.elm
+++ b/src/Select/Select/Input.elm
@@ -1,7 +1,7 @@
 module Select.Select.Input exposing (..)
 
 import Html exposing (..)
-import Html.Attributes exposing (attribute, class, placeholder, value, style, autocomplete)
+import Html.Attributes exposing (attribute, class, placeholder, value, style, autocomplete, id)
 import Html.Events exposing (on, onInput, onWithOptions, keyCode)
 import Array
 import Json.Decode as Decode
@@ -142,20 +142,29 @@ view config model items selected =
                   Nothing
                 Just n ->
                   Array.fromList found |> Array.get (rem n (List.length found)) -- items wrap around
+
+        idAttribute =
+          case config.inputId of
+            Nothing ->
+              []
+            Just inputId ->
+              [ id inputId ]
     in
         div [ class rootClasses, style rootStyles ]
             [ input
-                [ class inputClasses
-                , autocomplete False
-                , attribute "autocorrect" "off" -- for mobile Safari
-                , onBlurAttribute config model
-                , onKeyUpAttribute highlightedItem
-                , onInput OnQueryChange
-                , placeholder config.prompt
-                , referenceAttr config model
-                , style inputStyles
-                , value val
-                ]
+                (
+                  [ class inputClasses
+                  , autocomplete False
+                  , attribute "autocorrect" "off" -- for mobile Safari
+                  , onBlurAttribute config model
+                  , onKeyUpAttribute highlightedItem
+                  , onInput OnQueryChange
+                  , placeholder config.prompt
+                  , referenceAttr config model
+                  , style inputStyles
+                  , value val
+                  ] ++ idAttribute
+                )
                 []
             , underline
             , clear


### PR DESCRIPTION
This allows configuration of the ID attribute for the input element.

I need this because I want to have a search button on my page, which shows the search box and then sets focus to it.  Unfortunately `Dom.focus` only allow passing an ID and not a class.

An alternative to this would be to provide a generic `withInputAttributes` to allow any arbitrary  attributes to be added to the input (or the other elements with similar functions).

If you think that is a better approach, feel free to close this PR and I'll create another to do it that way instead.

