### PR TITLE
Enter selects single item

### DIFF
--- a/src/Select/Select/Input.elm
+++ b/src/Select/Select/Input.elm
@@ -131,10 +131,14 @@ view config model items selected =
         matchedItems =
           matchedItemsWithCutoff config model items
 
-        highlightedItem =
+        -- item that will be selected if enter if pressed
+        preselectedItem =
           case matchedItems of
             Select.Utils.NotSearched ->
               Nothing
+
+            Select.Utils.ItemsFound [singleItem] ->
+              Just singleItem
 
             Select.Utils.ItemsFound found ->
               case model.highlightedItem of
@@ -157,7 +161,7 @@ view config model items selected =
                   , autocomplete False
                   , attribute "autocorrect" "off" -- for mobile Safari
                   , onBlurAttribute config model
-                  , onKeyUpAttribute highlightedItem
+                  , onKeyUpAttribute preselectedItem
                   , onInput OnQueryChange
                   , placeholder config.prompt
                   , referenceAttr config model


### PR DESCRIPTION
This is a minor usability improvement .

If there is only one item in the list it can be selected by pressing enter directly without having to first press the down arrow to highlight it.  For example, in the demo, if you type "Lion" and then press enter it will select "The Lion King"

If you think this behaviour should not be the default and set via a config parameter I can change it.