### PR TITLE
Add withOnFocus

### DIFF
--- a/src/Select.elm
+++ b/src/Select.elm
@@ -34,6 +34,7 @@ module Select
         , withHighlightedItemClass
         , withHighlightedItemStyles
         , withOnQuery
+        , withOnFocus
         , withPrompt
         , withPromptClass
         , withPromptStyles
@@ -61,7 +62,7 @@ module Select
 
 # Configure the input
 
-@docs withInputId, withInputClass, withInputStyles, withInputWrapperClass, withInputWrapperStyles
+@docs withInputId, withInputClass, withInputStyles, withInputWrapperClass, withInputWrapperStyles, withOnFocus
 
 
 # Configure an underline element under the input
@@ -455,6 +456,18 @@ withOnQuery msg config =
     in
         fmapConfig fn config
 
+{-| Add a callback for when the input field receives focus
+
+    Select.withOnFocus OnFocus
+
+-}
+withOnFocus : msg -> Config msg item -> Config msg item
+withOnFocus msg config =
+    let
+        fn c =
+            { c | onFocus = Just msg }
+    in
+        fmapConfig fn config
 
 {-| Add classes to the prompt text (When no item is selected)
 Select.withPromptClass "prompt" config

--- a/src/Select/Messages.elm
+++ b/src/Select/Messages.elm
@@ -3,6 +3,7 @@ module Select.Messages exposing (..)
 
 type Msg item
     = NoOp
+    | OnFocus
     | OnBlur
     | OnClear
     | OnEsc

--- a/src/Select/Models.elm
+++ b/src/Select/Models.elm
@@ -34,6 +34,7 @@ type alias Config msg item =
     , highlightedItemStyles : List Style
     , onQueryChange : Maybe (String -> msg)
     , onSelect : Maybe item -> msg
+    , onFocus : Maybe msg
     , prompt : String
     , promptClass : String
     , promptStyles : List Style
@@ -73,6 +74,7 @@ newConfig onSelect toLabel =
     , highlightedItemStyles = []
     , onQueryChange = Nothing
     , onSelect = onSelect
+    , onFocus = Nothing
     , prompt = ""
     , promptClass = ""
     , promptStyles = []

--- a/src/Select/Select/Input.elm
+++ b/src/Select/Select/Input.elm
@@ -2,7 +2,7 @@ module Select.Select.Input exposing (..)
 
 import Html exposing (..)
 import Html.Attributes exposing (attribute, class, placeholder, value, style, autocomplete, id)
-import Html.Events exposing (on, onInput, onWithOptions, keyCode)
+import Html.Events exposing (on, onInput, onWithOptions, keyCode, onFocus)
 import Array
 import Json.Decode as Decode
 import Select.Events exposing (onBlurAttribute)
@@ -159,11 +159,13 @@ view config model items selected =
                   , onBlurAttribute config model
                   , onKeyUpAttribute highlightedItem
                   , onInput OnQueryChange
+                  , onFocus OnFocus
                   , placeholder config.prompt
                   , referenceAttr config model
                   , style inputStyles
                   , value val
                   ] ++ idAttribute
+
                 )
                 []
             , underline

--- a/src/Select/Update.elm
+++ b/src/Select/Update.elm
@@ -33,6 +33,17 @@ update config msg model =
             in
               ( { model | highlightedItem =  newHightlightedItem }, Cmd.none)
 
+        OnFocus ->
+            let
+                cmd =
+                    case config.onFocus of
+                      Nothing -> Cmd.none
+                      Just focusMessage ->
+                          Task.succeed Nothing
+                              |> Task.perform (\x -> focusMessage)
+            in
+              ( model, cmd )
+
         OnBlur ->
             ( { model | query = Nothing }, Cmd.none )
 


### PR DESCRIPTION
Provides a callback for when the search box gets focus.

I use this to scroll the search box to the top when the user clicks in it so there is plenty of space below it to show the suggestions.  This is particularly important on a tablet in landscape orientation as the virtual keyboard takes up half of the screen.