### PR TITLE
Remove debug log statement on fuzzing

### DIFF
--- a/src/Select/Search.elm
+++ b/src/Select/Search.elm
@@ -44,7 +44,6 @@ matchedItems config query items =
                         let
                             scoreFor =
                                 scoreForItem config query
-                                    |> Debug.log "fuzzing"
                         in
                             items
                                 |> List.map (\item -> ( scoreFor item, item ))


### PR DESCRIPTION
Really small thing to clean up the console in production.