### PR TITLE
Fix typo in Styles.elm

### DIFF
--- a/src/Select/Styles.elm
+++ b/src/Select/Styles.elm
@@ -93,7 +93,7 @@ multiInputItemStyles =
 
 multiInputItemText : List ( String, String )
 multiInputItemText =
-    [ ( "text-overflow", "elpisis" )
+    [ ( "text-overflow", "ellipsis" )
     , ( "padding-left", ".5rem" )
     , ( "padding-right", ".3rem" )
     , ( "padding-top", ".05rem" )


### PR DESCRIPTION
I'm not entirely sure when this ellipsis is supposed to show up, but right now it doesn't show up at all, so we should probably fix that.