### PR TITLE
Prevent the default action of the Enter key

### DIFF
--- a/src/Select/Select/Input.elm
+++ b/src/Select/Select/Input.elm
@@ -12,12 +12,12 @@ import Html.Attributes
         , style
         , value
         )
-import Html.Events exposing (keyCode, on, onFocus, onInput, stopPropagationOn)
+import Html.Events exposing (keyCode, preventDefaultOn, onFocus, onInput, stopPropagationOn)
 import Json.Decode as Decode
 import Select.Config exposing (Config)
 import Select.Events exposing (onBlurAttribute)
 import Select.Messages as Msg exposing (Msg)
-import Select.Models as Models exposing (State)
+import Select.Models exposing (State)
 import Select.Search as Search
 import Select.Select.Clear as Clear
 import Select.Select.RemoveItem as RemoveItem
@@ -43,7 +43,13 @@ onKeyPressAttribute maybeItem =
                 _ ->
                     Decode.fail "not TAB or ENTER"
     in
-    on "keypress" (Decode.andThen fn keyCode)
+    preventDefaultOn "keypress"
+        (Decode.andThen fn keyCode
+            |> Decode.andThen
+                (\msg ->
+                    Decode.succeed ( msg, True )
+                )
+        )
 
 
 onKeyUpAttribute : Maybe item -> Attribute (Msg item)
@@ -74,7 +80,13 @@ onKeyUpAttribute maybeItem =
                 _ ->
                     Decode.fail "not ENTER"
     in
-    on "keyup" (Decode.andThen fn keyCode)
+    preventDefaultOn "keyup"
+        (Decode.andThen fn keyCode
+            |> Decode.andThen
+                (\msg ->
+                    Decode.succeed ( msg, True )
+                )
+        )
 
 
 view : Config msg item -> State -> List item -> List item -> Html (Msg item)

--- a/src/Select/Select/Input.elm
+++ b/src/Select/Select/Input.elm
@@ -12,7 +12,7 @@ import Html.Attributes
         , style
         , value
         )
-import Html.Events exposing (keyCode, preventDefaultOn, onFocus, onInput, stopPropagationOn)
+import Html.Events exposing (keyCode, onFocus, onInput, preventDefaultOn, stopPropagationOn)
 import Json.Decode as Decode
 import Select.Config exposing (Config)
 import Select.Events exposing (onBlurAttribute)
@@ -45,10 +45,7 @@ onKeyPressAttribute maybeItem =
     in
     preventDefaultOn "keypress"
         (Decode.andThen fn keyCode
-            |> Decode.andThen
-                (\msg ->
-                    Decode.succeed ( msg, True )
-                )
+            |> Decode.map (\msg -> ( msg, True ))
         )
 
 
@@ -82,10 +79,7 @@ onKeyUpAttribute maybeItem =
     in
     preventDefaultOn "keyup"
         (Decode.andThen fn keyCode
-            |> Decode.andThen
-                (\msg ->
-                    Decode.succeed ( msg, True )
-                )
+            |> Decode.map (\msg -> ( msg, True ))
         )
 
 


### PR DESCRIPTION
Using `preventDefaultOn` in the decoders of the key presses prevents auto-submitting the form

Closes #42 