### PR TITLE
Fix example links and add demo link in Elm package

### DIFF
--- a/src/Select.elm
+++ b/src/Select.elm
@@ -18,9 +18,11 @@ module Select exposing
 
 {-| Select input with auto-complete
 
-See a full example of the select input [here](https://github.com/sporto/elm-select/tree/master/demo/src/Example1.elm)
+See a full example of the select input [here](https://github.com/sporto/elm-select/blob/master/demo/src/Example1Basic.elm)
 
-See a full example of the select input in multi mode [here](https://github.com/sporto/elm-select/tree/master/demo/src/Example3.elm)
+See a full example of the select input in multi mode [here](https://github.com/sporto/elm-select/blob/master/demo/src/Example3Multi.elm)
+
+See live demo [here](https://sporto.github.io/elm-select)
 
 
 # Types


### PR DESCRIPTION
I also added the demo link, it's only in the github readme atm. I think it's nice to have the demo link on the Elm package website as well.