### PR TITLE
Make `withTransformQuery` work as expected

### DIFF
--- a/demo/src/ExampleAsync.elm
+++ b/demo/src/ExampleAsync.elm
@@ -78,14 +78,6 @@ selectConfig =
         |> Select.withCutoff 12
         |> Select.withOnQuery OnQuery
         |> Select.withItemHtml itemHtml
-        |> Select.withTransformQuery
-            (\query ->
-                if String.length query < 3 then
-                    ""
-
-                else
-                    query
-            )
 
 
 fetchUrl : String -> String
@@ -118,7 +110,12 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         OnQuery query ->
-            ( model, fetch query )
+            if String.length query < 3 then
+                ( model, Cmd.none )
+
+            else
+                ( model, fetch query )
+            
 
         OnFetch result ->
             case result of

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -770,15 +770,12 @@ withPrompt prompt config =
     mapConfig fn config
 
 
-{-| Transform the input query before performing the search
-Return Nothing to prevent searching
+{-| Transform the input query
+Return "" to effectively disable searching.
 
-    transform : String -> Maybe String
+    transform : String -> String
     transform query =
-        if String.length query < 4 then
-            Nothing
-        else
-            Just query
+        ""
 
     config
     |> Select.withTransformQuery transform

--- a/src/Select/Update.elm
+++ b/src/Select/Update.elm
@@ -116,7 +116,7 @@ update config msg model =
                         _ ->
                             queryChangeCmd newQuery
             in
-            ( { model | highlightedItem = Nothing, query = Just value }, cmd )
+            ( { model | highlightedItem = Nothing, query = Just newQuery }, cmd )
 
         OnSelect item ->
             let


### PR DESCRIPTION
My use case: disable the search input. I want to make the select box work like a dropdown without the searching capability because there are only a handful of options. I don't want the user to be able to type anything. Since this isn't supported, I figured the simplest way to achieve it is to use `Select.withTransformQuery (always "")`, so that anything the user types is transformed to the empty string. This is how I expected `withTransformQuery` to work. However, it doesn't work that way. It only transforms the query that is sent to the user's specified `OnQuery` message handler, while the input retains the original value. To me this is unexpected behavior. It looks like the original use case for this is demonstrated in the `ExampleAsync` file. That desired behavior can easily be achieved without the use of `withTransformQuery`, but rather handling it with the proper logic within the handling of `OnQuery`.

This PR updates `withTransformQuery` functionality to the behavior I expect, i.e. updating the query in the input as well as the query that is passed to the `OnQuery` handler. I also updated the docs and `ExampleAsync` to be in alignment with this.