### PR TITLE
Make `OnQueryChange` obey `emptySearch`

### DIFF
--- a/src/Select/Update.elm
+++ b/src/Select/Update.elm
@@ -130,12 +130,11 @@ update config msg model =
                         |> config.transformQuery
 
                 cmd =
-                    case transformedQuery of
-                        "" ->
-                            Cmd.none
+                    if not (String.isEmpty transformedQuery) || config.emptySearch then
+                        queryChangeCmd transformedQuery
 
-                        _ ->
-                            queryChangeCmd transformedQuery
+                    else
+                        Cmd.none
             in
             ( { model | highlightedItem = Nothing, query = Just transformedValue }, cmd )
 


### PR DESCRIPTION
My use case: I am using `withEmptySearch True` to trigger the search on focus. If I type a letter, the `OnQuery` command happens as expected. But then if I press the backspace key to remove that character so that the input is empty again, I expect the `OnQuery` command to fire with the empty string. However, it does not fire at all. This change makes it so the `OnQuery` command does fire with the empty string only if `emptySearch` is `True`.