### PR TITLE
Add `withValueSeparators`

### DIFF
--- a/src/Select.elm
+++ b/src/Select.elm
@@ -12,6 +12,7 @@ module Select exposing
     , init, queryFromState, withQuery
     , view
     , update
+    , withValueSeparators
     )
 
 {-| Select input with auto-complete
@@ -840,6 +841,22 @@ withTransformQuery transform config =
     let
         fn c =
             { c | transformQuery = transform }
+    in
+    mapConfig fn config
+
+
+{-| Specify a custom list of separators for the query
+The default is `[ "\n", "\t", "," ]`
+
+    config
+        |> Select.withValueSeparators []
+
+-}
+withValueSeparators : List String -> Config msg item -> Config msg item
+withValueSeparators valueSeparators config =
+    let
+        fn c =
+            { c | valueSeparators = valueSeparators }
     in
     mapConfig fn config
 


### PR DESCRIPTION
I have a use case where my queries often include commas because the names of our products have commas in them, so I don't want them to be separated. This PR adds `withValueSeparators` to allow the user to configure the `config.valueSeparators` field.