### PR TITLE
add a `withMultiInputItemRemovable`

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,21 +1,21 @@
 {
-    "type": "package",
-    "name": "sporto/elm-select",
-    "summary": "A selection input with auto-completion",
-    "license": "MIT",
-    "version": "6.3.0",
-    "exposed-modules": [
-        "Select"
-    ],
-    "elm-version": "0.19.0 <= v < 0.20.0",
-    "dependencies": {
-        "elm/core": "1.0.0 <= v < 2.0.0",
-        "elm/html": "1.0.0 <= v < 2.0.0",
-        "elm/json": "1.0.0 <= v < 2.0.0",
-        "elm/regex": "1.0.0 <= v < 2.0.0",
-        "elm/svg": "1.0.0 <= v < 2.0.0"
-    },
-    "test-dependencies": {
-        "elm-explorations/test": "2.0.0 <= v < 3.0.0"
-    }
+  "type": "package",
+  "name": "Johnny2210/elm-select-fork",
+  "summary": "A selection input with auto-completion",
+  "license": "MIT",
+  "version": "6.3.0",
+  "exposed-modules": [
+    "Select"
+  ],
+  "elm-version": "0.19.0 <= v < 0.20.0",
+  "dependencies": {
+    "elm/core": "1.0.0 <= v < 2.0.0",
+    "elm/html": "1.0.0 <= v < 2.0.0",
+    "elm/json": "1.0.0 <= v < 2.0.0",
+    "elm/regex": "1.0.0 <= v < 2.0.0",
+    "elm/svg": "1.0.0 <= v < 2.0.0"
+  },
+  "test-dependencies": {
+    "elm-explorations/test": "2.0.0 <= v < 3.0.0"
+  }
 }

--- a/elm.json
+++ b/elm.json
@@ -1,21 +1,21 @@
 {
-  "type": "package",
-  "name": "sporto/elm-select",
-  "summary": "A selection input with auto-completion",
-  "license": "MIT",
-  "version": "6.3.0",
-  "exposed-modules": [
-    "Select"
-  ],
-  "elm-version": "0.19.0 <= v < 0.20.0",
-  "dependencies": {
-    "elm/core": "1.0.0 <= v < 2.0.0",
-    "elm/html": "1.0.0 <= v < 2.0.0",
-    "elm/json": "1.0.0 <= v < 2.0.0",
-    "elm/regex": "1.0.0 <= v < 2.0.0",
-    "elm/svg": "1.0.0 <= v < 2.0.0"
-  },
-  "test-dependencies": {
-    "elm-explorations/test": "2.0.0 <= v < 3.0.0"
-  }
+    "type": "package",
+    "name": "sporto/elm-select",
+    "summary": "A selection input with auto-completion",
+    "license": "MIT",
+    "version": "6.3.0",
+    "exposed-modules": [
+        "Select"
+    ],
+    "elm-version": "0.19.0 <= v < 0.20.0",
+    "dependencies": {
+        "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm/html": "1.0.0 <= v < 2.0.0",
+        "elm/json": "1.0.0 <= v < 2.0.0",
+        "elm/regex": "1.0.0 <= v < 2.0.0",
+        "elm/svg": "1.0.0 <= v < 2.0.0"
+    },
+    "test-dependencies": {
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0"
+    }
 }

--- a/elm.json
+++ b/elm.json
@@ -1,6 +1,6 @@
 {
   "type": "package",
-  "name": "Johnny2210/elm-select-fork",
+  "name": "sporto/elm-select",
   "summary": "A selection input with auto-completion",
   "license": "MIT",
   "version": "6.3.0",

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -12,7 +12,7 @@ module Select exposing
     , init, queryFromState, withQuery
     , view
     , update
-    , withMultiInputItemRemoveable
+    , withMultiInputItemRemovable
     )
 
 {-| Select input with auto-complete
@@ -542,17 +542,17 @@ withMultiInputItemMoreAttrs attrs config =
 {-| Which items are removeable from the list
 
     config
-        |> Select.withMultiInputItemRemoveable (\x -> x.removeable)
+        |> Select.withMultiInputItemRemovable (\x -> x.removeable)
 
 -}
-withMultiInputItemRemoveable :
+withMultiInputItemRemovable :
     (item -> Bool)
     -> Config msg item
     -> Config msg item
-withMultiInputItemRemoveable value config =
+withMultiInputItemRemovable value config =
     let
         fn c =
-            { c | multiInputItemRemoveable = Just value }
+            { c | multiInputItemRemovable = Just value }
     in
     mapConfig fn config
 

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -12,6 +12,7 @@ module Select exposing
     , init, queryFromState, withQuery
     , view
     , update
+    , withMultiInputItemRemoveable
     )
 
 {-| Select input with auto-complete
@@ -534,6 +535,24 @@ withMultiInputItemMoreAttrs attrs config =
     let
         fn c =
             { c | multiInputItemAttrs = c.multiInputItemAttrs ++ attrs }
+    in
+    mapConfig fn config
+
+
+{-| Which items are removeable from the list
+
+    config
+        |> Select.withMultiInputItemRemoveable (\x -> x.removeable)
+
+-}
+withMultiInputItemRemoveable :
+    (item -> Bool)
+    -> Config msg item
+    -> Config msg item
+withMultiInputItemRemoveable value config =
+    let
+        fn c =
+            { c | multiInputItemRemoveable = Just value }
     in
     mapConfig fn config
 

--- a/src/Select/Config.elm
+++ b/src/Select/Config.elm
@@ -38,7 +38,7 @@ type alias Config msg item =
     , menuAttrs : List (Attribute msg)
     , multiInputItemAttrs : List (Attribute msg)
     , multiInputItemContainerAttrs : List (Attribute msg)
-    , multiInputItemRemoveable : Maybe (item -> Bool)
+    , multiInputItemRemovable: Maybe (item -> Bool)
     , notFound : String
     , notFoundAttrs : List (Attribute msg)
     , notFoundShown : Bool
@@ -80,7 +80,7 @@ newConfig requiredConfig =
     , menuAttrs = []
     , multiInputItemAttrs = []
     , multiInputItemContainerAttrs = []
-    , multiInputItemRemoveable = Nothing
+    , multiInputItemRemovable = Nothing
     , notFound = "No results found"
     , notFoundAttrs = []
     , notFoundShown = True

--- a/src/Select/Config.elm
+++ b/src/Select/Config.elm
@@ -38,6 +38,7 @@ type alias Config msg item =
     , menuAttrs : List (Attribute msg)
     , multiInputItemAttrs : List (Attribute msg)
     , multiInputItemContainerAttrs : List (Attribute msg)
+    , multiInputItemRemoveable : Maybe (item -> Bool)
     , notFound : String
     , notFoundAttrs : List (Attribute msg)
     , notFoundShown : Bool
@@ -79,6 +80,7 @@ newConfig requiredConfig =
     , menuAttrs = []
     , multiInputItemAttrs = []
     , multiInputItemContainerAttrs = []
+    , multiInputItemRemoveable = Nothing
     , notFound = "No results found"
     , notFoundAttrs = []
     , notFoundShown = True

--- a/src/Select/Select/Input/Multi.elm
+++ b/src/Select/Select/Input/Multi.elm
@@ -85,7 +85,7 @@ currentSelection_item_maybeClear config item =
 
 currentSelection_item_clear config item =
     let
-        removeableHtml =
+        removableHtml =
             div
                 [ class classNames.multiInputItemRemove
                 , Shared.onClickWithoutPropagation (Msg.OnRemoveItem item)
@@ -93,13 +93,13 @@ currentSelection_item_clear config item =
                 ]
                 [ RemoveItem.view config ]
     in
-    case config.multiInputItemRemoveable of
+    case config.multiInputItemRemovable of
         Nothing ->
-            removeableHtml
+            removableHtml
 
         Just fn ->
             if fn item then
-                removeableHtml
+                removableHtml
 
             else
                 div [] []

--- a/src/Select/Select/Input/Multi.elm
+++ b/src/Select/Select/Input/Multi.elm
@@ -84,9 +84,22 @@ currentSelection_item_maybeClear config item =
 
 
 currentSelection_item_clear config item =
-    div
-        [ class classNames.multiInputItemRemove
-        , Shared.onClickWithoutPropagation (Msg.OnRemoveItem item)
-            |> Html.Attributes.map config.toMsg
-        ]
-        [ RemoveItem.view config ]
+    let
+        removeableHtml =
+            div
+                [ class classNames.multiInputItemRemove
+                , Shared.onClickWithoutPropagation (Msg.OnRemoveItem item)
+                    |> Html.Attributes.map config.toMsg
+                ]
+                [ RemoveItem.view config ]
+    in
+    case config.multiInputItemRemoveable of
+        Nothing ->
+            removeableHtml
+
+        Just fn ->
+            if fn item then
+                removeableHtml
+
+            else
+                div [] []


### PR DESCRIPTION
I had the use case, that my multi input select items had a bunch of default items, which should not be removable. I added the `withMultiInputItemRemovable` to remove the `clear` icon from items, which are not supposed to be "unselected". They also will not trigger the `withOnRemoveItem` message.