### PR TITLE
Use `itemAttrs` as intended

### DIFF
--- a/src/Select/Select/Item.elm
+++ b/src/Select/Select/Item.elm
@@ -56,6 +56,7 @@ view config state itemCount selectedItems index item =
          , onMouseDown (config.toMsg (OnSelect item))
          , referenceAttr config state
          ]
+            ++ config.itemAttrs
             ++ highlightedItemAttrs
             ++ selectedAttrs
         )


### PR DESCRIPTION
I need to add a custom attribute to every item in the select list. It looks like `withItemAttrs` is designed for that, but the underlying `itemAttrs` property of `Config` isn't being used.  This uses it in the way it seems was intended.