### PR TITLE
Use `itemAttrs` in view and support per-item attributes

### DIFF
--- a/src/Select.elm
+++ b/src/Select.elm
@@ -5,7 +5,7 @@ module Select exposing
     , withInputWrapperAttrs, withInputWrapperMoreAttrs
     , withInputAttrs, withInputMoreAttrs, withOnFocus, withOnBlur, withOnEsc, withValueSeparators
     , withClear, withClearAttrs, withClearMoreAttrs, withClearSvgClass, withClearHtml
-    , withItemAttrs, withItemMoreAttrs, withItemHtml, withHighlightedItemAttrs, withHighlightedItemMoreAttrs, withItemSelectedAttrs, withItemSelectedMoreAttrs
+    , withItemAttrs, withItemHtml, withHighlightedItemAttrs, withHighlightedItemMoreAttrs, withItemSelectedAttrs, withItemSelectedMoreAttrs
     , withMenuAttrs, withMenuMoreAttrs
     , withNotFound, withNotFoundAttrs, withNotFoundMoreAttrs, withNotFoundShown
     , withPrompt, withPromptAttrs, withPromptMoreAttrs
@@ -57,7 +57,7 @@ This is the element that wraps the selected item(s) and the input
 
 # Configure the items
 
-@docs withItemAttrs, withItemMoreAttrs, withItemHtml, withHighlightedItemAttrs, withHighlightedItemMoreAttrs, withItemSelectedAttrs, withItemSelectedMoreAttrs
+@docs withItemAttrs, withItemHtml, withHighlightedItemAttrs, withHighlightedItemMoreAttrs, withItemSelectedAttrs, withItemSelectedMoreAttrs
 
 
 # Configure the menu
@@ -367,33 +367,6 @@ withItemAttrs attrs config =
     let
         fn c =
             { c | itemAttrs = Just attrs }
-    in
-    mapConfig fn config
-
-
-{-| Add attributes to the items.
-This adds to existing attributes.
-
-    config
-        |> Select.withItemMoreAttrs (\i -> [ class ("item-" ++ i.status) ])
-
--}
-withItemMoreAttrs :
-    (item -> List (Attribute msg))
-    -> Config msg item
-    -> Config msg item
-withItemMoreAttrs attrs config =
-    let
-        fn c =
-            { c
-                | itemAttrs =
-                    case c.itemAttrs of
-                        Just existingAttrs ->
-                            Just (\i -> existingAttrs i ++ attrs i)
-
-                        Nothing ->
-                            Just attrs
-            }
     in
     mapConfig fn config
 

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -356,17 +356,17 @@ withInputWrapperMoreAttrs attrs config =
 This overrides any attributes already set in a previous call.
 
     config
-        |> Select.withItemAttrs [ class "border-bottom" ]
+        |> Select.withItemAttrs (\i -> [ class ("item-" ++ i.status) ])
 
 -}
 withItemAttrs :
-    List (Attribute msg)
+    (item -> List (Attribute msg))
     -> Config msg item
     -> Config msg item
 withItemAttrs attrs config =
     let
         fn c =
-            { c | itemAttrs = attrs }
+            { c | itemAttrs = Just attrs }
     in
     mapConfig fn config
 
@@ -375,17 +375,25 @@ withItemAttrs attrs config =
 This adds to existing attributes.
 
     config
-        |> Select.withItemMoreAttrs [ class "border-bottom" ]
+        |> Select.withItemMoreAttrs (\i -> [ class ("item-" ++ i.status) ])
 
 -}
 withItemMoreAttrs :
-    List (Attribute msg)
+    (item -> List (Attribute msg))
     -> Config msg item
     -> Config msg item
 withItemMoreAttrs attrs config =
     let
         fn c =
-            { c | itemAttrs = c.itemAttrs ++ attrs }
+            { c
+                | itemAttrs =
+                    case c.itemAttrs of
+                        Just existingAttrs ->
+                            Just (\i -> existingAttrs i ++ attrs i)
+
+                        Nothing ->
+                            Just attrs
+            }
     in
     mapConfig fn config
 

--- a/src/Select/Config.elm
+++ b/src/Select/Config.elm
@@ -33,12 +33,12 @@ type alias Config msg item =
     , inputAttrs : List (Attribute msg)
     , inputWrapperAttrs : List (Attribute msg)
     , isMultiSelect : Bool
-    , itemAttrs : List (Attribute msg)
+    , itemAttrs : Maybe (item -> List (Attribute msg))
     , itemHtml : Maybe (item -> Html msg)
     , menuAttrs : List (Attribute msg)
     , multiInputItemAttrs : List (Attribute msg)
     , multiInputItemContainerAttrs : List (Attribute msg)
-    , multiInputItemRemovable: Maybe (item -> Bool)
+    , multiInputItemRemovable : Maybe (item -> Bool)
     , notFound : String
     , notFoundAttrs : List (Attribute msg)
     , notFoundShown : Bool
@@ -75,7 +75,7 @@ newConfig requiredConfig =
     , inputAttrs = []
     , inputWrapperAttrs = []
     , isMultiSelect = False
-    , itemAttrs = []
+    , itemAttrs = Nothing
     , itemHtml = Nothing
     , menuAttrs = []
     , multiInputItemAttrs = []

--- a/src/Select/Select/Item.elm
+++ b/src/Select/Select/Item.elm
@@ -41,6 +41,14 @@ view config state itemCount selectedItems index item =
         label =
             config.toLabel item
 
+        itemAttrs =
+            case config.itemAttrs of
+                Nothing ->
+                    []
+
+                Just fn ->
+                    fn item
+
         itemHtml =
             case config.itemHtml of
                 Nothing ->
@@ -56,6 +64,7 @@ view config state itemCount selectedItems index item =
          , onMouseDown (config.toMsg (OnSelect item))
          , referenceAttr config state
          ]
+            ++ itemAttrs
             ++ highlightedItemAttrs
             ++ selectedAttrs
         )


### PR DESCRIPTION
Hi! Thanks for publishing and maintaining this package.

This PR uses `Config.itemAttrs` in `Select.Item.view` (it was previously unused) and updates `withItemAttrs` and `withItemMoreAttrs` so that item attributes are a function of each item.

Before:
```elm
withItemAttrs : List (Attribute msg) -> Config msg item -> Config msg item
```

After:
```elm
withItemAttrs : (item -> List (Attribute msg)) -> Config msg item -> Config msg item
```

`Config.itemAttrs` is now `Maybe (item -> List (Attribute msg))` instead of `List (Attribute msg)`.

This enables applying custom attributes per item in the dropdown list (e.g. styling or data attributes based on the item).

Resolves #62